### PR TITLE
Fixes issue WordPress not starting

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
-version: '2'
+version: '3.7'
 services:
   mariadb:
-    image: 'bitnami/mariadb:10.3'
+    image: 'bitnami/mariadb:latest'
     volumes:
       - 'mariadb_data:/bitnami'
     environment:

--- a/wordpress-server-block.conf
+++ b/wordpress-server-block.conf
@@ -1,0 +1,23 @@
+server {
+  listen 0.0.0.0:80;
+  server_name myapp.example.com;
+
+  root /opt/bitnami/wordpress;
+  index index.php;
+
+  location / {
+    try_files $uri $uri/ /index.php?q=$uri&$args;
+  }
+
+  if (!-e $request_filename)
+  {
+    rewrite ^/(.+)$ /index.php?q=$1 last;
+  }
+
+  location ~ \.php$ {
+    fastcgi_pass localhost:9000;
+    fastcgi_index index.php;
+    fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+    include fastcgi_params;
+  }
+}


### PR DESCRIPTION
I added default wordpress-server-block.conf file and changed the docker compose file version to version 3.7 (most current, and recommended according to docker, see: https://docs.docker.com/compose/compose-file/compose-versioning/)

This PR will also fix issue #9