### PR TITLE
Updating documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ $ docker run -d --name wordpress \
   -e WORDPRESS_DATABASE_NAME=bitnami_wordpress \
   --network wordpress-network \
   --volume wordpress_data:/bitnami/wordpress \
-  --volume ./wordpress-vhosts.conf:/bitnami/nginx/conf/server_blocks/wordpress-vhosts.conf \
+  --volume ./wordpress-server-block.conf:/opt/bitnami/nginx/conf/server_blocks/wordpress-server-block.conf \
   bitnami/wordpress-nginx:latest
 ```
 
@@ -130,7 +130,7 @@ This requires a minor change to the [`docker-compose.yml`](https://github.com/bi
      volumes:
 -      - 'wordpress_data:/bitnami/wordpress
 +      - /path/to/wordpress-persistence:/bitnami/wordpress
-       - ./wordpress-vhosts.conf:/bitnami/nginx/conf/server_blocks/wordpress-vhosts.conf
+       - ./wordpress-server-block.conf:/opt/bitnami/nginx/conf/server_blocks/wordpress-server-block.conf
    ...
 -volumes:
 -  mariadb_data:
@@ -169,7 +169,7 @@ $ docker run -d --name wordpress \
   --env WORDPRESS_DATABASE_NAME=bitnami_wordpress \
   --network wordpress-network \
   --volume /path/to/wordpress-persistence:/bitnami/wordpress \
-  --volume ./wordpress-vhosts.conf:/bitnami/nginx/conf/server_blocks/wordpress-vhosts.conf \
+  --volume ./wordpress-server-block.conf:/opt/bitnami/nginx/conf/server_blocks/wordpress-server-block.conf \
   bitnami/wordpress-nginx:latest
 ```
 
@@ -291,7 +291,7 @@ $ docker run -d --name wordpress \
   --env ALLOW_EMPTY_PASSWORD=yes --env WORDPRESS_DATABASE_USER=bn_wordpress \
   --env WORDPRESS_DATABASE_NAME=bitnami_wordpress \
   --volume wordpress_data:/bitnami/wordpress-nginx \
-  --volume ./wordpress-vhosts.conf:/bitnami/nginx/conf/server_blocks/wordpress-vhosts.conf \
+  --volume ./wordpress-server-block.conf:/opt/bitnami/nginx/conf/server_blocks/wordpress-server-block.conf \
   bitnami/wordpress-nginx:latest
 ```
 
@@ -334,7 +334,7 @@ $ docker run -d --name wordpress \
   --env WORDPRESS_DATABASE_USER=wordpress_user \
   --env WORDPRESS_DATABASE_PASSWORD=wordpress_password \
   --volume wordpress_data:/bitnami/wordpress \
-  --volume ./wordpress-vhosts.conf:/bitnami/nginx/conf/server_blocks/wordpress-vhosts.conf \
+  --volume ./wordpress-server-block.conf:/opt/bitnami/nginx/conf/server_blocks/wordpress-server-block.conf \
   bitnami/wordpress-nginx:latest
 ```
 


### PR DESCRIPTION
* Updating form wordpress-vhosts.conf to wordpress-server-block.conf
* Updating from /bitnami/nginx/conf/server_blocks to /opt/bitnami/nginx/conf/server_blocks

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Seems that "wordpress-server-vhosts.conf" was mistyped instead of "wordpress-server-block.conf"
and we are updating from /bitnami/nginx/conf/server_blocks to /opt/bitnami/nginx/conf/server_blocks

**Benefits**

Will make the documentation more accurate

**Possible drawbacks**

N/A

**Applicable issues**

N/A

**Additional information**

I think it mean to be "wordpress-server-block.conf", because this environment is Nginx based.
/opt/ prepended on mounting strings, to point to right directory.
